### PR TITLE
이슈 4591처리

### DIFF
--- a/lib/js/literallycanvas.js
+++ b/lib/js/literallycanvas.js
@@ -872,7 +872,7 @@ module.exports = LiterallyCanvas = (function() {
         results.push(s.getBoundingRect(this.ctx));
       }
       return results;
-    }).call(this), explicitSize, margin);
+    }).call(this), explicitSize, margin, this.backgroundShapes);
   };
 
   LiterallyCanvas.prototype.getImage = function(opts) {
@@ -3852,7 +3852,7 @@ util = {
     x = arg.x, y = arg.y, width = arg.width, height = arg.height;
     return ("<svg xmlns='http://www.w3.org/2000/svg' width='" + width + "' height='" + height + "' viewBox='0 0 " + width + " " + height + "'> <rect width='" + width + "' height='" + height + "' x='0' y='0' fill='" + backgroundColor + "' /> <g transform='translate(" + (-x) + ", " + (-y) + ")'> " + (shapes.map(renderShapeToSVG).join('')) + " </g> </svg>").replace(/(\r\n|\n|\r)/gm, "");
   },
-  getBoundingRect: function(rects, width, height) {
+  getBoundingRect: function(rects, width, height, backgroundShapes) {
     var i, len, maxX, maxY, minX, minY, rect;
     if (!rects.length) {
       return {
@@ -3873,6 +3873,11 @@ util = {
       maxX = Math.ceil(Math.max(maxX, rect.x + rect.width));
       maxY = Math.ceil(Math.max(maxY, rect.y + rect.height));
     }
+    if (backgroundShapes.length > 0) {
+      rect = backgroundShapes[0];
+      maxX = rect.x + rect.width;
+      maxY = rect.y + rect.height;
+    }
     minX = width ? 0 : minX;
     minY = height ? 0 : minY;
     maxX = width || maxX;
@@ -3884,7 +3889,7 @@ util = {
       height: maxY - minY
     };
   },
-  getDefaultImageRect: function(shapeBoundingRects, explicitSize, margin) {
+  getDefaultImageRect: function(shapeBoundingRects, explicitSize, margin, backgroundShapes) {
     var height, rect, width;
     if (explicitSize == null) {
       explicitSize = {
@@ -3900,8 +3905,11 @@ util = {
         left: 0
       };
     }
+    if (backgroundShapes == null) {
+      backgroundShapes = [];
+    }
     width = explicitSize.width, height = explicitSize.height;
-    rect = util.getBoundingRect(shapeBoundingRects, width === 'infinite' ? 0 : width, height === 'infinite' ? 0 : height);
+    rect = util.getBoundingRect(shapeBoundingRects, width === 'infinite' ? 0 : width, height === 'infinite' ? 0 : height, backgroundShapes);
     rect.x -= margin.left;
     rect.y -= margin.top;
     rect.width += margin.left + margin.right;

--- a/lib/js/literallycanvas.js
+++ b/lib/js/literallycanvas.js
@@ -3854,6 +3854,9 @@ util = {
   },
   getBoundingRect: function(rects, width, height, backgroundShapes) {
     var i, len, maxX, maxY, minX, minY, rect;
+    if (backgroundShapes == null) {
+      backgroundShapes = [];
+    }
     if (!rects.length) {
       return {
         x: 0,
@@ -3878,8 +3881,8 @@ util = {
       maxX = rect.x + rect.width;
       maxY = rect.y + rect.height;
     }
-    minX = width ? 0 : minX;
-    minY = height ? 0 : minY;
+    minX = width ? 0 : Math.max(minX, 0);
+    minY = height ? 0 : Math.max(minY, 0);
     maxX = width || maxX;
     maxY = height || maxY;
     return {

--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -475,7 +475,8 @@ module.exports = class LiterallyCanvas
     return util.getDefaultImageRect(
       (s.getBoundingRect(@ctx) for s in @shapes.concat(@backgroundShapes)),
       explicitSize,
-      margin )
+      margin,
+      @backgroundShapes )
 
   getImage: (opts={}) ->
     opts.includeWatermark ?= true

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -79,7 +79,7 @@ util =
     ".replace(/(\r\n|\n|\r)/gm,"")
 
   # [{x, y, width, height}]
-  getBoundingRect: (rects, width, height, backgroundShapes) ->
+  getBoundingRect: (rects, width, height, backgroundShapes = []) ->
     return {x: 0, y: 0, width: 0 or width, height: 0 or height} unless rects.length
 
     # Calculate the bounds for infinite canvas
@@ -99,8 +99,8 @@ util =
       maxY = rect.y + rect.height
 
     # Use the image size bounds if they exist
-    minX = if width then 0 else minX
-    minY = if height then 0 else minY
+    minX = if width then 0 else Math.max(minX, 0)
+    minY = if height then 0 else Math.max(minY, 0)
     maxX = width or maxX
     maxY = height or maxY
 

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -79,7 +79,7 @@ util =
     ".replace(/(\r\n|\n|\r)/gm,"")
 
   # [{x, y, width, height}]
-  getBoundingRect: (rects, width, height) ->
+  getBoundingRect: (rects, width, height, backgroundShapes) ->
     return {x: 0, y: 0, width: 0 or width, height: 0 or height} unless rects.length
 
     # Calculate the bounds for infinite canvas
@@ -93,6 +93,11 @@ util =
       maxX = Math.ceil Math.max(maxX, rect.x + rect.width)
       maxY = Math.ceil Math.max(maxY, rect.y + rect.height)
 
+    if backgroundShapes.length > 0
+      rect = backgroundShapes[0]
+      maxX = rect.x + rect.width
+      maxY = rect.y + rect.height
+
     # Use the image size bounds if they exist
     minX = if width then 0 else minX
     minY = if height then 0 else minY
@@ -105,13 +110,15 @@ util =
   getDefaultImageRect: (
       shapeBoundingRects,
       explicitSize={width: 0, height: 0},
-      margin={top: 0, right: 0, bottom: 0, left: 0}) ->
+      margin={top: 0, right: 0, bottom: 0, left: 0},
+      backgroundShapes=[]) ->
     {width, height} = explicitSize
 
     rect = util.getBoundingRect(
       shapeBoundingRects,
       if width == 'infinite' then 0 else width,
-      if height == 'infinite' then 0 else height)
+      if height == 'infinite' then 0 else height,
+      backgroundShapes)
 
     rect.x -= margin.left
     rect.y -= margin.top


### PR DESCRIPTION
boolgom/Entry#4591

이슈처리

원인 : 기본 canvas의 사이즈는 960 540 고정이지만 실제 그린 이미지는 이보다 더 커질수도 있다.
이경우 fill처리시 canvas의 사이즈내에서 계산이아니고 최대 shape의 rect사이즈를 기준으로 처리하여 
fill이 잘못처리되는것으로 보여지고 있었다.

해결 : fill처리시 backgroundShapes 를 넘기고 최종 rect 계산을 960 540에 맞출수 있도록 처리하였음.